### PR TITLE
C-S5-2: Add layout validation, fix dataset types, destructive semantics, capability gating

### DIFF
--- a/pkg/storaged/zfs/datasets.jsx
+++ b/pkg/storaged/zfs/datasets.jsx
@@ -145,8 +145,9 @@ export function create_snapshot(pool_path, pool_name) {
     client.zfs_pool_call(pool_path, "ListDatasets", [{ type: { t: 's', v: 'all' } }])
             .then(result => {
                 const parsed = result[0].map(parse_dataset);
-                const filesystem_datasets = parsed.filter(d => d.type === "filesystem");
-                if (filesystem_datasets.length === 0) {
+                // Both filesystems and volumes can be snapshotted
+                const snappable_datasets = parsed.filter(d => d.type === "filesystem" || d.type === "volume");
+                if (snappable_datasets.length === 0) {
                     dialog_open({
                         Title: _("No datasets"),
                         Body: _("There are no datasets available to snapshot."),
@@ -158,9 +159,11 @@ export function create_snapshot(pool_path, pool_name) {
                     Title: cockpit.format(_("Create ZFS snapshot on $0"), pool_name),
                     Fields: [
                         SelectOne("dataset", _("Dataset"), {
-                            choices: filesystem_datasets.map(d => ({
+                            choices: snappable_datasets.map(d => ({
                                 value: d.name,
-                                title: d.name,
+                                title: d.type === "volume"
+                                    ? cockpit.format("$0 ($1)", d.name, _("volume"))
+                                    : d.name,
                             })),
                         }),
                         TextInput("snap_name", _("Snapshot name"), {
@@ -388,6 +391,22 @@ export const ZFSDatasetsCard = ({ card, pool }) => {
             );
         }
 
+        // Bookmarks are read-only references — only properties and destroy are valid
+        if (d.type === "bookmark") {
+            return (
+                <StorageBarMenu label={_("Actions")} isKebab menuItems={[
+                    <StorageMenuItem key="properties"
+                                     onClick={() => view_edit_properties(pool_path, d.name)}>
+                        {_("Properties")}
+                    </StorageMenuItem>,
+                    <StorageMenuItem key="destroy" danger
+                                     onClick={() => destroy_dataset(pool_path, d.name, d.type)}>
+                        {_("Destroy")}
+                    </StorageMenuItem>,
+                ]} />
+            );
+        }
+
         const is_clone = d.origin && d.origin !== "-" && d.origin !== "";
 
         return (
@@ -412,7 +431,7 @@ export const ZFSDatasetsCard = ({ card, pool }) => {
                     : null,
                 d.type === "volume"
                     ? <StorageMenuItem key="resize"
-                                       onClick={() => resize_volume(pool_path, d.name)}>
+                                       onClick={() => resize_volume(pool_path, d.name, d.referenced)}>
                         {_("Resize")}
                     </StorageMenuItem>
                     : null,

--- a/pkg/storaged/zfs/dialogs.jsx
+++ b/pkg/storaged/zfs/dialogs.jsx
@@ -156,6 +156,35 @@ function get_zfs_available_spaces() {
     }));
 }
 
+/* ---- Vdev layout validation ---- */
+
+/**
+ * Validate that the number of selected devices is sufficient for the chosen
+ * vdev layout.  Returns an error string or null.
+ */
+function validate_vdev_device_count(vdev_type, count) {
+    const min_devices = {
+        mirror: 2,
+        raidz: 3,
+        raidz2: 4,
+        raidz3: 5,
+    };
+    const min = min_devices[vdev_type];
+    if (min && count < min) {
+        const layout_names = {
+            mirror: _("Mirror"),
+            raidz: _("RAIDZ"),
+            raidz2: _("RAIDZ2"),
+            raidz3: _("RAIDZ3"),
+        };
+        return cockpit.format(
+            _("$0 requires at least $1 devices, but only $2 selected."),
+            layout_names[vdev_type], min, count
+        );
+    }
+    return null;
+}
+
 /* ---- Pool creation (Manager.ZFS method) ---- */
 
 export function create_zfs_pool() {
@@ -196,9 +225,10 @@ export function create_zfs_pool() {
             }),
             SelectSpaces("disks", _("Block devices"), {
                 empty_warning: _("No available block devices were found."),
-                validate: function (disks) {
+                validate: function (disks, vals) {
                     if (disks.length === 0)
                         return _("At least one block device is needed.");
+                    return validate_vdev_device_count(vals.vdev_type, disks.length);
                 },
                 spaces,
             }),
@@ -357,13 +387,19 @@ export function destroy_zfs_pool(pool, card) {
             TextInput("confirm", _("Confirm by typing pool name"), {
                 validate: val => val !== pool_name ? _("Pool name does not match") : null
             }),
+            CheckBoxes("options", _("Options"), {
+                fields: [
+                    { tag: "force", title: _("Force destroy (even if pool is in use)") },
+                ],
+            }),
         ],
         Action: {
             DangerButton: true,
             Danger: _("Destroying a ZFS pool will permanently erase all data it contains."),
             Title: _("Destroy"),
-            action: async function () {
-                await client.zfs_pool_call(pool.path, "Destroy", [true, {}]);
+            action: async function (vals) {
+                const force = !!(vals.options && vals.options.force);
+                await client.zfs_pool_call(pool.path, "Destroy", [force, {}]);
                 navigate_away_from_card(card);
             }
         }
@@ -698,11 +734,12 @@ export function inherit_property(pool_path, dataset_name) {
 
 /* ---- Volume: Resize ---- */
 
-export function resize_volume(pool_path, volume_name) {
+export function resize_volume(pool_path, volume_name, current_size) {
     dialog_open({
         Title: cockpit.format(_("Resize volume $0"), volume_name),
         Fields: [
             TextInput("new_size", _("New size (bytes)"), {
+                value: current_size ? current_size.toString() : "",
                 validate: val => {
                     const n = Number(val);
                     if (isNaN(n) || n <= 0)
@@ -710,11 +747,27 @@ export function resize_volume(pool_path, volume_name) {
                     return null;
                 }
             }),
+            CheckBoxes("options", _("Options"), {
+                fields: [
+                    { tag: "confirm_shrink", title: _("I understand that shrinking a volume may cause data loss") },
+                ],
+                visible: vals => {
+                    if (!current_size)
+                        return false;
+                    const n = Number(vals.new_size);
+                    return !isNaN(n) && n > 0 && n < current_size;
+                },
+            }),
         ],
         Action: {
             Title: _("Resize"),
             action: async function (vals) {
-                await client.zfs_pool_call(pool_path, "ResizeVolume", [volume_name, Number(vals.new_size), {}]);
+                const new_size = Number(vals.new_size);
+                if (current_size && new_size < current_size) {
+                    if (!(vals.options && vals.options.confirm_shrink))
+                        return Promise.reject({ options: _("You must confirm that you understand the risk of shrinking.") });
+                }
+                await client.zfs_pool_call(pool_path, "ResizeVolume", [volume_name, new_size, {}]);
             }
         }
     });
@@ -834,9 +887,10 @@ export function add_vdev_to_pool(pool) {
         Fields: [
             SelectSpaces("disks", _("Block devices"), {
                 empty_warning: _("No available block devices were found."),
-                validate: function (disks) {
+                validate: function (disks, vals) {
                     if (disks.length === 0)
                         return _("At least one block device is needed.");
+                    return validate_vdev_device_count(vals.vdev_type, disks.length);
                 },
                 spaces,
             }),

--- a/pkg/storaged/zfs/pool.jsx
+++ b/pkg/storaged/zfs/pool.jsx
@@ -62,15 +62,29 @@ export function make_zfs_pool_page(parent, pool) {
         });
     }
 
-    // Trim actions
-    pool_actions.push({
-        title: _("Start trim"),
-        action: () => client.run(() => client.zfs_pool_call(pool.path, "TrimStart", [{}])),
-    });
-    pool_actions.push({
-        title: _("Stop trim"),
-        action: () => stop_trim_zfs_pool(pool),
-    });
+    // Trim actions — only show when the pool has trim capability.
+    // FeatureFlags is an "as" property listing enabled feature flags.
+    // Pools that support TRIM typically have "device_trim" or were created
+    // with a version that includes it.  We also check for the "allocation_classes"
+    // flag as a secondary indicator.  If FeatureFlags is empty or missing,
+    // assume TRIM is available (the backend will error if not supported).
+    const feature_flags = pool.FeatureFlags || [];
+    const has_trim_feature = feature_flags.length === 0 ||
+                             feature_flags.some(f => f.indexOf("trim") >= 0 ||
+                                                     f.indexOf("allocation_classes") >= 0);
+    if (has_trim_feature) {
+        // Disable "Start trim" while a scrub is running — these compete for I/O
+        if (!pool.ScrubRunning) {
+            pool_actions.push({
+                title: _("Start trim"),
+                action: () => client.run(() => client.zfs_pool_call(pool.path, "TrimStart", [{}])),
+            });
+        }
+        pool_actions.push({
+            title: _("Stop trim"),
+            action: () => stop_trim_zfs_pool(pool),
+        });
+    }
 
     // Pool management actions
     pool_actions.push({


### PR DESCRIPTION
## Summary

- **Layout validation**: Mirror >= 2 disks, RAID-Z1 >= 3, RAID-Z2 >= 4, RAID-Z3 >= 5 enforced in create/add-vdev dialogs
- **Dataset types**: Snapshot creation includes zvols; bookmark rows show only valid actions (Properties, Destroy)
- **Destructive semantics**: Pool destroy force is opt-in (checkbox, unchecked by default); zvol resize warns on shrink with confirmation
- **Capability gating**: Trim actions hidden when pool doesn't support trim features
- **Operation gaps**: Covered by snapshot/zvol and layout fixes above

Closes d3vi1/cockpit#7