### PR TITLE
C-S6-1: Bring ZFS UI up to storaged conventions

### DIFF
--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -296,3 +296,39 @@ td.job-action {
 .pf-v6-c-button .pf-v6-c-truncate span {
     text-decoration: var(--pf-v6-c-button--TextDecorationLine) var(--pf-v6-c-button--TextDecorationStyle);
 }
+
+// ZFS state indicator colors — used for pool/vdev state dots and text
+.zfs-state--online {
+  color: var(--pf-t--global--color--status--success--default);
+}
+
+.zfs-state--degraded {
+  color: var(--pf-t--global--color--status--warning--default);
+}
+
+.zfs-state--faulted {
+  color: var(--pf-t--global--color--status--danger--default);
+}
+
+.zfs-state--offline {
+  color: var(--pf-t--global--text--color--subtle);
+}
+
+// ZFS vdev tree indentation via CSS custom property
+.zfs-vdev-indent {
+  padding-inline-start: calc(var(--pf-t--global--spacer--lg) * var(--zfs-vdev-level, 0));
+}
+
+// ZFS vdev error highlight
+.zfs-vdev-error {
+  color: var(--pf-t--global--color--status--danger--default);
+}
+
+// ZFS properties / history dialog pre block
+.zfs-properties-pre {
+  white-space: pre-wrap;
+  max-block-size: 400px;
+  overflow: auto;
+  font-family: var(--pf-t--global--font--family--mono);
+  font-size: var(--pf-t--global--font--size--sm);
+}

--- a/pkg/storaged/zfs/datasets.jsx
+++ b/pkg/storaged/zfs/datasets.jsx
@@ -14,7 +14,7 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { EmptyState, EmptyStateBody } from "@patternfly/react-core/dist/esm/components/EmptyState/index.js";
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
-import { Badge } from "@patternfly/react-core/dist/esm/components/Badge/index.js";
+import { Label } from "@patternfly/react-core/dist/esm/components/Label/index.js";
 
 import { InputGroup, InputGroupItem, InputGroupText } from "@patternfly/react-core/dist/esm/components/InputGroup/index.js";
 import { TextInput as TextInputPF } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
@@ -22,7 +22,7 @@ import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/comp
 
 import { StorageCard } from "../pages.jsx";
 import { StorageBarMenu, StorageMenuItem } from "../storage-controls.jsx";
-import { dialog_open, TextInput, SelectOne } from "../dialog.jsx";
+import { dialog_open, TextInput, SizeSlider, SelectOne } from "../dialog.jsx";
 import { fmt_size } from "../utils.js";
 import {
     promote_clone, hold_snapshot, release_snapshot,
@@ -108,6 +108,9 @@ export function create_filesystem(pool_path, pool_name) {
 }
 
 export function create_volume(pool_path, pool_name) {
+    const pool = client.zfs_pools[pool_path];
+    const max_size = pool ? Number(pool.Free) : undefined;
+
     dialog_open({
         Title: cockpit.format(_("Create ZFS volume on $0"), pool_name),
         Fields: [
@@ -122,19 +125,15 @@ export function create_volume(pool_path, pool_name) {
                     return null;
                 }
             }),
-            TextInput("size", _("Size (bytes)"), {
-                validate: val => {
-                    const n = Number(val);
-                    if (isNaN(n) || n <= 0)
-                        return _("Size must be a positive number");
-                    return null;
-                }
+            SizeSlider("size", _("Size"), {
+                max: max_size,
+                round: 512,
             }),
         ],
         Action: {
             Title: _("Create"),
             action: async function (vals) {
-                await client.zfs_pool_call(pool_path, "CreateVolume", [vals.name, Number(vals.size), {}]);
+                await client.zfs_pool_call(pool_path, "CreateVolume", [vals.name, vals.size, {}]);
             }
         }
     });
@@ -313,7 +312,7 @@ function type_label(type) {
     }
 }
 
-function type_badge_color(type) {
+function type_label_color(type) {
     switch (type) {
     case "filesystem": return "blue";
     case "volume": return "cyan";
@@ -339,7 +338,6 @@ export const ZFSDatasetsCard = ({ card, pool }) => {
                     setError(null);
                 })
                 .catch(err => {
-                    console.warn("ListDatasets failed:", err);
                     setError(err.toString());
                 });
     }, [pool_path]);
@@ -510,10 +508,9 @@ export const ZFSDatasetsCard = ({ card, pool }) => {
                                 <Tr key={d.name}>
                                     <Td>{d.name}</Td>
                                     <Td>
-                                        <Badge screenReaderText={type_label(d.type)}
-                                               style={{ backgroundColor: type_badge_color(d.type) }}>
+                                        <Label isCompact color={type_label_color(d.type)}>
                                             {type_label(d.type)}
-                                        </Badge>
+                                        </Label>
                                     </Td>
                                     <Td>{d.mountpoint}</Td>
                                     <Td>{d.type === "filesystem" ? (d.mounted ? _("Yes") : _("No")) : "-"}</Td>

--- a/pkg/storaged/zfs/device.jsx
+++ b/pkg/storaged/zfs/device.jsx
@@ -13,7 +13,7 @@ import { DescriptionList } from "@patternfly/react-core/dist/esm/components/Desc
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 
 import { StorageCard, StorageDescription, new_card, register_crossref } from "../pages.jsx";
-import { fmt_zfs_state, zfs_pool_state_color } from "./utils.jsx";
+import { fmt_zfs_state, zfs_state_css_class } from "./utils.jsx";
 import { import_zfs_pool } from "./dialogs.jsx";
 
 const _ = cockpit.gettext;
@@ -121,7 +121,7 @@ const ZFSDeviceCard = ({ card, block, content_block, zfs_proxy, is_zvol, pool_na
                     <StorageDescription title={_("Pool state")}>
                         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
-                                <span style={{ color: zfs_pool_state_color(pool.State) }}>&#x2B24;</span>
+                                <span className={"zfs-state-dot " + zfs_state_css_class(pool.State)}>&#x2B24;</span>
                             </FlexItem>
                             <FlexItem>
                                 {fmt_zfs_state(pool.State)}

--- a/pkg/storaged/zfs/dialogs.jsx
+++ b/pkg/storaged/zfs/dialogs.jsx
@@ -8,7 +8,7 @@ import React from "react";
 import client from "../client";
 
 import {
-    dialog_open, TextInput, SelectOne, SelectSpaces, CheckBoxes,
+    dialog_open, TextInput, SizeSlider, SelectOne, SelectSpaces, CheckBoxes,
 } from "../dialog.jsx";
 import {
     block_name, drive_name, fmt_size, block_cmp,
@@ -373,8 +373,7 @@ export function import_zfs_pool() {
                     }
                 });
             })
-            .catch(err => {
-                console.warn("ListImportablePools failed, falling back to text input:", err);
+            .catch(() => {
                 import_zfs_pool_with_text_fallback();
             });
 }
@@ -593,7 +592,7 @@ export function view_history_zfs_pool(pool) {
                 const history_text = result[0] || _("No history available.");
                 dialog_open({
                     Title: cockpit.format(_("History for pool $0"), pool.Name),
-                    Body: <pre style={{ whiteSpace: "pre-wrap", maxHeight: "400px", overflow: "auto" }}>{history_text}</pre>,
+                    Body: <pre className="zfs-properties-pre">{history_text}</pre>,
                     Fields: [],
                     Action: {
                         Title: _("Close"),
@@ -715,17 +714,15 @@ export function inherit_property(pool_path, dataset_name) {
 /* ---- Volume: Resize ---- */
 
 export function resize_volume(pool_path, volume_name, current_size) {
+    const pool = client.zfs_pools[pool_path];
+    const max_size = pool ? Number(pool.Free) : undefined;
+
     dialog_open({
         Title: cockpit.format(_("Resize volume $0"), volume_name),
         Fields: [
-            TextInput("new_size", _("New size (bytes)"), {
-                value: current_size ? current_size.toString() : "",
-                validate: val => {
-                    const n = Number(val);
-                    if (isNaN(n) || n <= 0)
-                        return _("Size must be a positive number");
-                    return null;
-                }
+            SizeSlider("new_size", _("New size"), {
+                max: max_size,
+                round: 512,
             }),
             CheckBoxes("options", _("Options"), {
                 fields: [
@@ -795,7 +792,7 @@ export function view_edit_properties(pool_path, dataset_name) {
 
         dialog_open({
             Title: cockpit.format(_("Properties of $0"), dataset_name),
-            Body: <pre style={{ whiteSpace: "pre-wrap", maxHeight: "400px", overflow: "auto", fontFamily: "monospace", fontSize: "12px" }}>
+            Body: <pre className="zfs-properties-pre">
                 {header + "\n" + "─".repeat(60) + "\n" + lines}
             </pre>,
             Fields: [],
@@ -845,7 +842,7 @@ export function view_edit_pool_properties(pool) {
 
         dialog_open({
             Title: cockpit.format(_("Properties of pool $0"), pool_name),
-            Body: <pre style={{ whiteSpace: "pre-wrap", maxHeight: "400px", overflow: "auto", fontFamily: "monospace", fontSize: "12px" }}>
+            Body: <pre className="zfs-properties-pre">
                 {header + "\n" + "─".repeat(60) + "\n" + lines}
             </pre>,
             Fields: [],

--- a/pkg/storaged/zfs/pool.jsx
+++ b/pkg/storaged/zfs/pool.jsx
@@ -19,7 +19,7 @@ import {
 } from "../pages.jsx";
 import { StorageUsageBar } from "../storage-controls.jsx";
 import { fmt_size_long } from "../utils.js";
-import { fmt_zfs_state, zfs_pool_state_color, formatPoolGuid } from "./utils.jsx";
+import { fmt_zfs_state, zfs_state_css_class, formatPoolGuid, fmt_dedup_ratio, fmt_fragmentation } from "./utils.jsx";
 import { ZFSDatasetsCard, create_filesystem, create_volume, create_snapshot } from "./datasets.jsx";
 import { ZFSVdevCard } from "./vdev.jsx";
 import {
@@ -169,7 +169,7 @@ export function make_zfs_pool_page(parent, pool) {
 }
 
 const ZFSPoolCard = ({ card, pool, use }) => {
-    const state_color = zfs_pool_state_color(pool.State);
+    const state_css = zfs_state_css_class(pool.State);
     const state_text = fmt_zfs_state(pool.State);
     const health_text = fmt_zfs_state(pool.Health);
 
@@ -194,7 +194,7 @@ const ZFSPoolCard = ({ card, pool, use }) => {
                     <StorageDescription title={_("State")}>
                         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
-                                <span style={{ color: state_color }}>&#x2B24;</span>
+                                <span className={"zfs-state-dot " + state_css}>&#x2B24;</span>
                             </FlexItem>
                             <FlexItem>
                                 {state_text}
@@ -206,8 +206,8 @@ const ZFSPoolCard = ({ card, pool, use }) => {
                     <StorageDescription title={_("Usage")}>
                         <StorageUsageBar key="s" stats={use} />
                     </StorageDescription>
-                    <StorageDescription title={_("Dedup ratio")} value={pool.DedupRatio} />
-                    <StorageDescription title={_("Fragmentation")} value={pool.Fragmentation} />
+                    <StorageDescription title={_("Dedup ratio")} value={fmt_dedup_ratio(pool.DedupRatio)} />
+                    <StorageDescription title={_("Fragmentation")} value={fmt_fragmentation(pool.Fragmentation)} />
                     <StorageDescription title={_("Read only")} value={pool.ReadOnly ? _("Yes") : _("No")} />
                     { pool.Altroot && pool.Altroot !== "-" &&
                     <StorageDescription title={_("Alternate root")} value={pool.Altroot} />

--- a/pkg/storaged/zfs/utils.jsx
+++ b/pkg/storaged/zfs/utils.jsx
@@ -7,16 +7,20 @@ import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
 
-export function zfs_pool_state_color(state) {
+/**
+ * Return a CSS class name for the given ZFS state.
+ * These classes are defined in storage.scss and use PatternFly design tokens.
+ */
+export function zfs_state_css_class(state) {
     switch (state) {
-    case "ONLINE": return "green";
-    case "DEGRADED": return "orange";
-    case "FAULTED": return "red";
+    case "ONLINE": return "zfs-state--online";
+    case "DEGRADED": return "zfs-state--degraded";
+    case "FAULTED": return "zfs-state--faulted";
     case "OFFLINE":
     case "REMOVED":
     case "UNAVAIL":
     case "UNKNOWN":
-    default: return "grey";
+    default: return "zfs-state--offline";
     }
 }
 
@@ -40,4 +44,24 @@ export function fmt_zfs_state(state) {
     case "UNKNOWN": return _("Unknown");
     default: return state || _("Unknown");
     }
+}
+
+/**
+ * Format a dedup ratio (D-Bus type 'd' / double) for display.
+ * Example: 1.0 -> "1.00x", 2.5 -> "2.50x"
+ */
+export function fmt_dedup_ratio(ratio) {
+    if (ratio == null || isNaN(ratio))
+        return "-";
+    return Number(ratio).toFixed(2) + "x";
+}
+
+/**
+ * Format fragmentation (D-Bus type 't' / uint64, percentage) for display.
+ * Example: 5 -> "5%", 0 -> "0%"
+ */
+export function fmt_fragmentation(frag) {
+    if (frag == null || isNaN(frag))
+        return "-";
+    return Number(frag) + "%";
 }

--- a/pkg/storaged/zfs/vdev.jsx
+++ b/pkg/storaged/zfs/vdev.jsx
@@ -8,14 +8,14 @@ import React, { useState, useEffect, useCallback } from "react";
 import client from "../client";
 
 import { CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
-import { Badge } from "@patternfly/react-core/dist/esm/components/Badge/index.js";
+import { Label } from "@patternfly/react-core/dist/esm/components/Label/index.js";
 import { EmptyState, EmptyStateBody } from "@patternfly/react-core/dist/esm/components/EmptyState/index.js";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { StorageCard } from "../pages.jsx";
 import { StorageBarMenu, StorageMenuItem } from "../storage-controls.jsx";
-import { zfs_pool_state_color, fmt_zfs_state } from "./utils.jsx";
+import { zfs_state_css_class, fmt_zfs_state } from "./utils.jsx";
 import {
     replace_zfs_vdev, attach_zfs_vdev, detach_zfs_vdev,
     online_zfs_vdev, offline_zfs_vdev,
@@ -131,37 +131,35 @@ function vdev_actions_menu(pool, vdev, parent_vdev) {
 }
 
 function renderVdev(pool, vdev, depth, key_prefix, parent_vdev) {
-    const indent = depth * 24;
-    const state_color = zfs_pool_state_color(vdev.state);
+    const state_css = zfs_state_css_class(vdev.state);
     const state_text = fmt_zfs_state(vdev.state);
     const display_name = vdev.path || vdev_type_label(vdev.type) || _("Unknown device");
     const has_errors = vdev.read_errors > 0 || vdev.write_errors > 0 || vdev.checksum_errors > 0;
+    const error_class = has_errors ? "zfs-vdev-error" : undefined;
 
     const rows = [];
     rows.push(
         <Tr key={key_prefix}>
-            <Td style={{ paddingLeft: indent + "px" }}>
+            <Td className="zfs-vdev-indent" style={{ "--zfs-vdev-level": depth }}>
                 {depth === 0 && vdev.type &&
-                    <Badge isRead style={{ marginRight: "8px" }}>
-                        {vdev_type_label(vdev.type)}
-                    </Badge>
+                    <Label className="pf-v6-u-mr-sm" isCompact>{vdev_type_label(vdev.type)}</Label>
                 }
-                <span style={{ fontWeight: depth === 0 ? "bold" : "normal" }}>
+                <span className={depth === 0 ? "pf-v6-u-font-weight-bold" : undefined}>
                     {depth === 0 ? (vdev.path || vdev_type_label(vdev.type) || _("Unknown device")) : display_name}
                 </span>
             </Td>
             <Td>
-                <span style={{ color: state_color }}>
+                <span className={"zfs-state-text " + state_css}>
                     {state_text}
                 </span>
             </Td>
-            <Td style={has_errors ? { color: "var(--pf-t--global--color--status--danger--default)" } : {}}>
+            <Td className={error_class}>
                 {vdev.read_errors}
             </Td>
-            <Td style={has_errors ? { color: "var(--pf-t--global--color--status--danger--default)" } : {}}>
+            <Td className={error_class}>
                 {vdev.write_errors}
             </Td>
-            <Td style={has_errors ? { color: "var(--pf-t--global--color--status--danger--default)" } : {}}>
+            <Td className={error_class}>
                 {vdev.checksum_errors}
             </Td>
             <Td isActionCell>
@@ -194,7 +192,6 @@ export const ZFSVdevCard = ({ card, pool }) => {
                     setError(null);
                 })
                 .catch(err => {
-                    console.warn("GetVdevTopology failed:", err);
                     setError(err.toString());
                 });
     }, [pool_path]);


### PR DESCRIPTION
## Summary

- **PatternFly styling**: Replaced all inline styles with CSS classes using PF design tokens (state colors, indentation, badges)
- **Console cleanup**: Removed all console.warn/console.log from ZFS components
- **Value formatting**: Dedup ratio as Xx, fragmentation as X%, not raw numbers
- **Size inputs**: Replaced raw byte TextInput with SizeSlider in zvol create/resize
- **Consistent patterns**: Label components instead of Badge, CSS classes instead of inline, pre blocks styled via class

Closes d3vi1/cockpit#12