### PR TITLE
Fix export UX: navigate away on success, clear stale vdev/dataset cards on error

### DIFF
--- a/pkg/storaged/zfs/datasets.jsx
+++ b/pkg/storaged/zfs/datasets.jsx
@@ -347,6 +347,7 @@ export const ZFSDatasetsCard = ({ card, pool }) => {
                 })
                 .catch(err => {
                     setError(err.toString());
+                    setDatasets(null);
                 });
     }, [pool_path]);
 
@@ -497,7 +498,7 @@ export const ZFSDatasetsCard = ({ card, pool }) => {
                         <EmptyStateBody>{_("No datasets")}</EmptyStateBody>
                     </EmptyState>
                 }
-                { datasets !== null && filtered.length > 0 &&
+                { datasets !== null && filtered.length > 0 && !error &&
                     <Table aria-label={_("ZFS datasets")} variant="compact">
                         <Thead>
                             <Tr>

--- a/pkg/storaged/zfs/dialogs.jsx
+++ b/pkg/storaged/zfs/dialogs.jsx
@@ -380,7 +380,7 @@ export function import_zfs_pool() {
 
 /* ---- Pool export ---- */
 
-export function export_zfs_pool(pool) {
+export function export_zfs_pool(pool, card) {
     dialog_open({
         Title: cockpit.format(_("Export pool $0?"), pool.Name),
         Body: <div>
@@ -390,6 +390,7 @@ export function export_zfs_pool(pool) {
             Title: _("Export"),
             action: async function () {
                 await client.zfs_pool_call(pool.path, "Export", [false, {}]);
+                navigate_away_from_card(card);
             }
         }
     });

--- a/pkg/storaged/zfs/pool.jsx
+++ b/pkg/storaged/zfs/pool.jsx
@@ -106,7 +106,7 @@ export function make_zfs_pool_page(parent, pool) {
 
     pool_actions.push({
         title: _("Export pool"),
-        action: () => export_zfs_pool(pool),
+        action: () => export_zfs_pool(pool, pool_card),
     });
 
     pool_actions.push({

--- a/pkg/storaged/zfs/vdev.jsx
+++ b/pkg/storaged/zfs/vdev.jsx
@@ -212,6 +212,7 @@ export const ZFSVdevCard = ({ card, pool }) => {
                 })
                 .catch(err => {
                     setError(err.toString());
+                    setTopology(null);
                 });
     }, [pool_path]);
 
@@ -244,7 +245,7 @@ export const ZFSVdevCard = ({ card, pool }) => {
                         <EmptyStateBody>{_("No vdev information available")}</EmptyStateBody>
                     </EmptyState>
                 }
-                { topology !== null && topology.length > 0 &&
+                { topology !== null && topology.length > 0 && !error &&
                     <Table aria-label={_("ZFS vdev topology")} variant="compact">
                         <Thead>
                             <Tr>


### PR DESCRIPTION
## Summary
- Export now navigates away from pool page on success (matches destroy behavior)
- Vdev/dataset cards clear stale data when refresh fails
- Table rendering suppressed when error is active

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)